### PR TITLE
feat: focus only when user is tabbing

### DIFF
--- a/src/css/global.css
+++ b/src/css/global.css
@@ -36,3 +36,10 @@ body {
 body.inspect * {
   outline: 1px solid var(--inspect-color) !important;
 }
+
+body:not(.user-is-tabbing) button:focus,
+body:not(.user-is-tabbing) input:focus,
+body:not(.user-is-tabbing) select:focus,
+body:not(.user-is-tabbing) textarea:focus {
+  outline: none;
+}

--- a/src/hooks/use-tabbing-detect.ts
+++ b/src/hooks/use-tabbing-detect.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+
+// https://medium.com/hackernoon/removing-that-ugly-focus-ring-and-keeping-it-too-6c8727fefcd2
+function handleFirstTab(event: KeyboardEvent) {
+  if (event.code === `Tab`) {
+    document.body.classList.add('user-is-tabbing')
+    window.removeEventListener('keydown', handleFirstTab)
+  }
+}
+
+export const useTabbingDetect = () => {
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    window.addEventListener('keydown', handleFirstTab)
+
+    return () => {
+      window.removeEventListener('keydown', handleFirstTab)
+    }
+  }, [])
+
+  return null
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import { useAppGA } from 'lib/ga'
 import { AppContextProvider } from 'context/app'
 import { useMousetrap } from 'hooks/use-mousetrap'
 import { isDev } from 'lib/constants'
+import { useTabbingDetect } from 'hooks/use-tabbing-detect'
 
 const App = ({ Component, pageProps }: AppProps) => {
   if (isDev) {
@@ -16,6 +17,7 @@ const App = ({ Component, pageProps }: AppProps) => {
   }
 
   useAppGA()
+  useTabbingDetect()
 
   return (
     <AppContextProvider>


### PR DESCRIPTION
### Changes
- Adding `use-detect-tabbing` hook to detect when the user is tabbing through the css class '.user-is-tabbing'
- Implemented as the default behavior