### PR TITLE
Adding get size utility

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -14,3 +14,30 @@ export const formatError = (
 }
 
 export const isApiSupported = (api: string) => isClient && api in window
+
+/* Builds responsive sizes string for images */
+export const getSizes = (
+  entries: ({ breakpoint: string; width: string } | string | number)[]
+) => {
+  const sizes = entries.map((entry) => {
+    if (!entry) {
+      return ''
+    }
+
+    if (typeof entry === 'string') {
+      return entry
+    }
+
+    if (typeof entry === 'number') {
+      return `${entry}px`
+    }
+
+    if (entry.breakpoint.includes('px')) {
+      return `(min-width: ${entry.breakpoint}) ${entry.width}`
+    }
+
+    throw new Error(`Invalid breakpoint: ${entry.breakpoint}`)
+  })
+
+  return sizes.join(', ')
+}

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -32,7 +32,7 @@ export const getSizes = (
       return `${entry}px`
     }
 
-    if (entry.breakpoint.includes('px')) {
+    if (entry.breakpoint.includes('px') || entry.breakpoint.includes('rem')) {
       return `(min-width: ${entry.breakpoint}) ${entry.width}`
     }
 


### PR DESCRIPTION
Adding the `getSize` utility as a way to build the responsive string for the `sizes` prop on the `next/image` component.

https://nextjs.org/docs/api-reference/next/image#sizes

Usage:
```jsx
<Image
  src={image.src}
  layout="fill"
  sizes={getSizes([
    {
      breakpoint: '1024px',
      width: "50vw"
    },
    image.width / 2
  ])}
/>
```

This way of using it is almost like the `clsx` utility for classes, is resilient to `falsy` values excluding them from the final string and you can even tweak it to make it work with tailwind `screens` (Not included in this PR, but its easier to do if you have this centralized in a function).

```jsx
  <Image
    src={image.src}
    layout="fill"
    sizes={getSizes([
      {
        breakpoint: 'lg', // <-- Here
        width: "50vw"
      },
      image.width / 2
    ])}
  />
```