### PR TITLE
add useIsomorphicLayoutEffect hook and lint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,12 @@
       "@typescript-eslint/ban-ts-comment": 0,
       "simple-import-sort/imports": "warn",
       "simple-import-sort/exports": "warn",
-      "react-hooks/exhaustive-deps": "error",
+      "react-hooks/exhaustive-deps": [
+        "warn",
+        {
+          "additionalHooks": "(useIsomorphicLayoutEffect)"
+        }
+      ],
       "react/no-unescaped-entities": 0,
       "curly": [
         "error",

--- a/src/hooks/use-isomorphic-layout-effect.ts
+++ b/src/hooks/use-isomorphic-layout-effect.ts
@@ -1,0 +1,5 @@
+import { useEffect, useLayoutEffect } from 'react'
+
+import { isClient } from '~/lib/constants'
+
+export const useIsomorphicLayoutEffect = isClient ? useLayoutEffect : useEffect


### PR DESCRIPTION
New hook: useIsomorphicLayoutEffect and lint config for it

- This hook fixes this problem by switching between useEffect and useLayoutEffect following the execution environment.
- Lint exhaustive-deps was configured to validate the dependencies of this hook. You should be able to call this hook and see the linter warning and use the Quick Fix option.
- Change lint `react-hooks/exhaustive-deps` from `error` to `warn` 