### PR TITLE
Use generic on hook use-intersection-observer ref

### DIFF
--- a/src/hooks/use-intersection-observer.ts
+++ b/src/hooks/use-intersection-observer.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-export const useIntersectionObserver = <T extends HTMLElement>(
+export const useIntersectionObserver = <T extends Element>(
   options: IntersectionObserverInit & { triggerOnce?: boolean }
 ) => {
   const ref = React.useRef<T>(null)

--- a/src/hooks/use-intersection-observer.ts
+++ b/src/hooks/use-intersection-observer.ts
@@ -1,9 +1,9 @@
 import * as React from 'react'
 
-export const useIntersectionObserver = (
+export const useIntersectionObserver = <T extends HTMLElement>(
   options: IntersectionObserverInit & { triggerOnce?: boolean }
 ) => {
-  const ref = React.useRef<HTMLDivElement>(null)
+  const ref = React.useRef<T>(null)
   const [inView, setInView] = React.useState(false)
 
   React.useEffect(() => {


### PR DESCRIPTION
A little type improvement to support any type of HTMLElement that you want to set
