### PR TITLE
Wrong condition in use-image-fade-in hook

### DIFF
--- a/src/hooks/use-image-fade-in.ts
+++ b/src/hooks/use-image-fade-in.ts
@@ -3,7 +3,7 @@ import { useState } from 'react'
 export const useImageFadeIn = () => {
   const [loaded, setLoaded] = useState(false)
   return {
-    style: { opacity: loaded ? 1 : undefined, transition: 'opacity 200ms ease' },
+    style: { opacity: loaded ? undefined : 0},
     onLoad: () => {
       setLoaded(true)
     }

--- a/src/hooks/use-image-fade-in.ts
+++ b/src/hooks/use-image-fade-in.ts
@@ -3,7 +3,7 @@ import { useState } from 'react'
 export const useImageFadeIn = () => {
   const [loaded, setLoaded] = useState(false)
   return {
-    style: { opacity: loaded ? undefined : 0},
+    style: { opacity: loaded ? undefined : 0 },
     onLoad: () => {
       setLoaded(true)
     }

--- a/src/hooks/use-image-fade-in.ts
+++ b/src/hooks/use-image-fade-in.ts
@@ -4,7 +4,7 @@ export const useImageFadeIn = () => {
   const [loaded, setLoaded] = useState(false)
   return {
     style: { opacity: loaded ? undefined : 0 },
-    onLoad: () => {
+    onLoadingComplete: () => {
       setLoaded(true)
     }
   }


### PR DESCRIPTION
This PR fixes the `use-image-fade-in` opacity condition and removes the inline transition style in order to be able to set any transition you want via stylesheet
