### PR TITLE
Update tsconfig.json - importsNotUsedAsValues is deprecated

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "target": "esnext",
     "noUncheckedIndexedAccess": true,
-    "importsNotUsedAsValues": "error",
+    "verbatimModuleSyntax": true,
     "baseUrl": "./src",
     "paths": {
       "~/public/*": ["../public/*"],


### PR DESCRIPTION
on tsconfig.json

`importsNotUsedAsValues` is deprecated https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues

replaced with `verbatimModuleSyntax` https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax