### PR TITLE
Remove next-transpile-modules

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,4 @@
 const withBundleAnalyzer = require('@next/bundle-analyzer')
-const withTM = require('next-transpile-modules')
 
 /**
  * @type {import('next').NextConfig}
@@ -15,8 +14,7 @@ const config = {
 
 module.exports = (_phase, { defaultConfig: _ }) => {
   const plugins = [
-    withBundleAnalyzer({ enabled: process.env.ANALYZE === 'true' }),
-    withTM([]) // add modules you want to transpile here
+    withBundleAnalyzer({ enabled: process.env.ANALYZE === 'true' })
   ]
   return plugins.reduce((acc, plugin) => plugin(acc), { ...config })
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "eslint-plugin-react-hooks": "4.3.0",
     "eslint-plugin-simple-import-sort": "7.0.0",
     "next-sitemap": "^2.5.14",
-    "next-transpile-modules": "^9.0.0",
     "prettier": "2.5.1",
     "sass": "1.49.9",
     "stylelint": "14.5.3",


### PR DESCRIPTION
Next 13.1 has [Built-in Module Transpilation](https://nextjs.org/blog/next-13-1#built-in-module-transpilation-stable) bringing next-transpile-modules capabilities into core

pending: update yarn.lock
