### PR TITLE
fix error type in valueOrUpdater fn use-storage

### DIFF
--- a/src/hooks/use-storage.ts
+++ b/src/hooks/use-storage.ts
@@ -30,8 +30,9 @@ export const useStorage = <Schema extends z.ZodTypeAny>(
     (valueOrUpdater: ValueOrUpdater<Value>) => {
       if (isDisabled) return
       const nextValue =
-        typeof valueOrUpdater === 'function'
-          ? // @ts-expect-error ???
+        valueOrUpdater instanceof Function
+          ? // @ts-expect-error (now it's failing because prev is undefined, i don't know what is prev, i think
+            // here should be `valueOrUpdater(query.data)` but im nt sure
             valueOrUpdater(prev)
           : valueOrUpdater
       window[type].setItem(key, JSON.stringify(nextValue))


### PR DESCRIPTION
# Fix error type in use-storage hook

```ts
const nextValue =
        valueOrUpdater instanceof Function
          ? valueOrUpdater(prev) // this line cause an error because `prev` is not defined
          : valueOrUpdater
```

I drop some comments in the code if you need 
f51009f98916d077ea2ab9a425e0245483503c3b

I hope this will help 🫡
